### PR TITLE
Fix specifying 'split-to-monorepo' option

### DIFF
--- a/migrate-downstream-fork.py
+++ b/migrate-downstream-fork.py
@@ -309,7 +309,7 @@ For migrating from the old monorepo to the new monorepo:
                       help="The prefix for all the refs of the old repository/repositories (default: %(default)s).")
   parser.add_argument('--old-repo-notes', metavar="REF", default=None,
                       help="Additionally check for svn revision numbers in the given notes ref.")
-  parser.add_argument('--source-kind', choices=["split", "monorepo", "auxilliary", "autodetect"], default="autodetect",
+  parser.add_argument('--source-kind', choices=["merge-split", "monorepo", "auxilliary", "autodetect"], default="autodetect",
                       help="What kind of old repository you have (default: autodetect)")
   parser.add_argument("reflist", metavar="REFPATTERN", help="Patterns of the references to convert.", nargs='+')
   parser.add_argument("--revmap-out", metavar="FILE", default=None)


### PR DESCRIPTION
In the rest of the script, the particular source_kind is called
'merge-split', but is 'split' in the option. This means there's no way
to specify the option besides letting autodetection figure it out.