### PR TITLE
migrate-downstream-fork: fixing souce-kind usage of 'split'

### DIFF
--- a/migrate-downstream-fork.py
+++ b/migrate-downstream-fork.py
@@ -111,7 +111,7 @@ class Migrator:
                           (subproject_set, split_repos))
         self.source_kind = "auxilliary"
       else:
-        self.source_kind = "merge-split"
+        self.source_kind = "split"
 
   def commit_filter(self, fm, githash, commit, oldparents):
     """Do the real filtering work..."""
@@ -221,7 +221,7 @@ class Migrator:
     print "Using conversion mode: %s (%s)." % (
         self.source_kind,
         {'monorepo' : 'Monorepo to monorepo',
-         'merge-split': 'Split repositories to monorepo',
+         'split': 'Split repositories to monorepo',
          'auxilliary': 'Auxilliary repo'}[self.source_kind],)
 
     print "Filtering commits..."


### PR DESCRIPTION
Only in actual argument description "split" source-kind is spelled as 'split'.
Every other place spells it as 'merge-split'. It does not affect autodetect
execution but leads to unpleasant effect when trying to specify 'split' manually.

Since in https://reviews.llvm.org/rL353713 source-kind was mentioned as 'split',
I figured that fixing it to 'split' spelling is a right way to go.